### PR TITLE
エラーページ作成

### DIFF
--- a/frontend/src/components/utilities/TextAlignContainer.tsx
+++ b/frontend/src/components/utilities/TextAlignContainer.tsx
@@ -1,0 +1,12 @@
+import { Box, BoxProps } from '@mui/material'
+
+type TextAlignContainerProps = {
+  align?: 'left' | 'center' | 'right' | 'justify'
+} & BoxProps
+
+const TextAlignContainer = ({
+  align = 'left',
+  ...props
+}: TextAlignContainerProps) => <Box {...props} sx={{ textAlign: align }} />
+
+export default TextAlignContainer

--- a/frontend/src/pages/InternalServerError.tsx
+++ b/frontend/src/pages/InternalServerError.tsx
@@ -2,16 +2,16 @@ import { Button, Typography } from '@mui/material'
 import { Link } from 'react-router-dom'
 import TextAlignContainer from '../components/utilities/TextAlignContainer'
 
-const NotFound = () => (
+const InternalServerError = () => (
   <TextAlignContainer align="center" mt={8}>
     <Typography variant="h1" sx={{ fontWeight: 'bold' }}>
-      404
+      500
     </Typography>
     <Typography variant="h3" sx={{ fontWeight: 'bold' }}>
-      Not Found
+      Internal Server Error
     </Typography>
     <Typography variant="h5" sx={{ mt: 2 }}>
-      ページが見つかりません
+      サーバーに問題が発生しました。後ほどもう一度お試しください。
     </Typography>
     <Button
       variant="contained"
@@ -25,4 +25,4 @@ const NotFound = () => (
   </TextAlignContainer>
 )
 
-export default NotFound
+export default InternalServerError

--- a/frontend/src/routes/Router.tsx
+++ b/frontend/src/routes/Router.tsx
@@ -1,12 +1,14 @@
 import React from 'react'
 import { Routes, Route } from 'react-router-dom'
 import Home from '../pages/Home'
+import InternalServerError from '../pages/InternalServerError'
 import NotFound from '../pages/NotFound'
 
 const Router: React.FC = () => {
   return (
     <Routes>
       <Route path="/" element={<Home />} />
+      <Route path="/500" element={<InternalServerError />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   )


### PR DESCRIPTION
## 概要

エラーページ作成

## 関連するissue番号

- #9 

## 行ったこと

- 404エラーページコンポーネントを修正
- 500エラーページコンポーネントを作成
- text-align用のコンポーネントを作成

## 動作確認

フロントエンド 
500 http://localhost:3001/error
404 http://localhost:3001/notfound

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a utility component for flexible text alignment, ensuring consistent presentation in user interfaces.
  - Launched a dedicated internal server error page featuring clear error messaging, localized content, and an easy navigation option to return home.
  
- **Refactor**
  - Revamped the Not Found page with an updated layout, enhanced styling, localized messaging, and improved navigation for a better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->