### PR TITLE
パスワード変更機能実装

### DIFF
--- a/backend/app/controllers/api/v1/auth/passwords_controller.rb
+++ b/backend/app/controllers/api/v1/auth/passwords_controller.rb
@@ -1,0 +1,31 @@
+class Api::V1::Auth::PasswordsController < Api::V1::BaseController
+  before_action :authenticate_user!
+  before_action :validate_current_password, only: :update
+  before_action :validate_new_password, only: :update
+
+  def update
+    if current_user.update(password_params.except(:current_password))
+      render json: { message: "パスワードが更新されました" }, status: :ok
+    else
+      render json: { error: current_user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+    def password_params
+      params.require(:user).permit(:current_password, :password, :password_confirmation)
+    end
+
+    def validate_current_password
+      unless current_user.valid_password?(password_params[:current_password])
+        render json: { error: "現在のパスワードが正しくありません" }, status: :unprocessable_entity
+      end
+    end
+
+    def validate_new_password
+      if password_params[:current_password] == password_params[:password]
+        render json: { error: "新しいパスワードは現在のパスワードと異なるものを設定してください" }, status: :unprocessable_entity
+      end
+    end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
         sessions: "api/v1/auth/sessions",
+        passwords: "api/v1/auth/passwords",
       }
 
       namespace :current do

--- a/backend/spec/requests/api/v1/auth/passwords_spec.rb
+++ b/backend/spec/requests/api/v1/auth/passwords_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth::Passwords", type: :request do
+  describe "PATCH /api/v1/auth/password" do
+    let!(:user) { create(:user) }
+    let(:headers) { user.create_new_auth_token }
+    let(:valid_params) do { user: { current_password: "password123", password: "newpassword123", password_confirmation: "newpassword123" } } end
+    let(:invalid_current_password_params) do
+      { user: { current_password: "wrongpassword", password: "newpassword123", password_confirmation: "newpassword123" } }
+    end
+    let(:same_password_params) do
+      { user: { current_password: "password123", password: "password123", password_confirmation: "password123" } }
+    end
+    let(:password_mismatch_params) do
+      { user: { current_password: "password123", password: "newpassword123", password_confirmation: "differentpassword123" } }
+    end
+    let(:empty_password_params) do
+      { user: { current_password: "password123", password: "", password_confirmation: "" } }
+    end
+
+    context "ログインしている場合" do
+      context "入力するパラメータが正しい場合" do
+        it "パスワードが変更される" do
+          patch "/api/v1/auth/password", headers: headers, params: valid_params
+
+          expect(response).to have_http_status(:ok)
+          expect(JSON.parse(response.body)["message"]).to eq("パスワードが更新されました")
+        end
+      end
+
+      context "現在のパスワードが間違っている場合" do
+        it "パスワード変更が失敗し、unprocessable_entity エラーが返る" do
+          patch "/api/v1/auth/password", headers: headers, params: invalid_current_password_params
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(JSON.parse(response.body)["error"]).to include("現在のパスワードが正しくありません")
+        end
+      end
+
+      context "現在のパスワードと新しいパスワードが同じ場合" do
+        it "パスワード変更が失敗し、unprocessable_entity エラーが返る" do
+          patch "/api/v1/auth/password", headers: headers, params: same_password_params
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(JSON.parse(response.body)["error"]).to include("新しいパスワードは現在のパスワードと異なるものを設定してください")
+        end
+      end
+
+      context "新しいパスワードと確認用パスワードが一致しない場合" do
+        it "パスワード変更が失敗し、unprocessable_entity エラーが返る" do
+          patch "/api/v1/auth/password", headers: headers, params: password_mismatch_params
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(JSON.parse(response.body)["error"]).to include("パスワード確認用とパスワードの入力が一致しません")
+        end
+      end
+
+      context "パスワードが空の場合" do
+        it "パスワード変更が失敗し、unprocessable_entity エラーが返る" do
+          patch "/api/v1/auth/password", headers: headers, params: empty_password_params
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(JSON.parse(response.body)["error"]).to include("パスワードを入力してください")
+        end
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "unauthorized エラーが返る" do
+        patch "/api/v1/auth/password"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -11,19 +11,30 @@ import {
   List,
   ListItem,
   ListItemText,
+  Menu,
+  MenuItem,
 } from '@mui/material'
-import { useState } from 'react'
+import { useState, MouseEvent } from 'react'
 import { Link } from 'react-router-dom'
 import { useCurrentUserState } from '../../hooks/useCurrentUser'
 
 export const Header = () => {
   const [currentUser] = useCurrentUserState()
   const [mobileOpen, setMobileOpen] = useState(false)
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
 
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen)
+  }
+
+  const handleSettingsClick = (event: MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handleMenuClose = () => {
+    setAnchorEl(null)
   }
 
   return (
@@ -72,13 +83,40 @@ export const Header = () => {
                   </>
                 )}
                 {currentUser.isSignedIn && (
-                  <Typography
-                    component={Link}
-                    to="/signout"
-                    sx={{ cursor: 'pointer', color: 'inherit' }}
-                  >
-                    ログアウト
-                  </Typography>
+                  <>
+                    <Typography
+                      component={Link}
+                      to="/signout"
+                      sx={{ cursor: 'pointer', color: 'inherit' }}
+                    >
+                      ログアウト
+                    </Typography>
+                    <Typography
+                      sx={{
+                        marginLeft: 2,
+                        cursor: 'pointer',
+                        color: 'inherit',
+                      }}
+                      onClick={handleSettingsClick} // 設定をクリックでドロップダウン
+                    >
+                      設定
+                    </Typography>
+
+                    {/* 設定のドロップダウンメニュー */}
+                    <Menu
+                      anchorEl={anchorEl}
+                      open={Boolean(anchorEl)}
+                      onClose={handleMenuClose}
+                      anchorOrigin={{
+                        vertical: 'bottom',
+                        horizontal: 'left',
+                      }}
+                    >
+                      <MenuItem component={Link} to="/password/edit">
+                        パスワード変更
+                      </MenuItem>
+                    </Menu>
+                  </>
                 )}
               </>
             )}
@@ -95,6 +133,12 @@ export const Header = () => {
                   <>
                     <ListItem component={Link} to="/signout">
                       <ListItemText primary="ログアウト" />
+                    </ListItem>
+                    <ListItem>
+                      <ListItemText primary="設定" />
+                    </ListItem>
+                    <ListItem component={Link} to="/password/edit">
+                      <ListItemText primary="パスワード変更" />
                     </ListItem>
                   </>
                 ) : (

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -3,6 +3,7 @@ const BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:3000'
 export const API_ENDPOINTS = {
   signup: `${BASE_URL}/api/v1/auth`,
   signin: `${BASE_URL}/api/v1/auth/sign_in`,
+  change_password: `${BASE_URL}/api/v1/auth/password`,
   current_user: `${BASE_URL}/api/v1/current/user`,
   drafts: {
     index: (page?: string) => `${BASE_URL}/api/v1/drafts/?page=${page}`,

--- a/frontend/src/pages/ChangePasswordForm.tsx
+++ b/frontend/src/pages/ChangePasswordForm.tsx
@@ -1,0 +1,129 @@
+import { Box, Container, Typography } from '@mui/material'
+import axios, { AxiosError, AxiosResponse } from 'axios'
+import { useState } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router'
+import { ErrorMessage } from '../components/form/ErrorMessage'
+import { Input } from '../components/form/Input'
+import { SubmitButton } from '../components/form/SubmitButton'
+import { TextAlignContainer } from '../components/utilities/TextAlignContainer'
+import { API_ENDPOINTS } from '../config/api'
+import { useSnackbar } from '../context/SnackbarContext'
+import { getAuthHeaders } from '../utils/getRequestHeaders'
+import { ChangePasswordValidation } from '../validations/changePasswordValidation'
+
+type ChangePasswordFormData = {
+  currentPassword: string
+  password: string
+  confirmPassword: string
+}
+
+const ChangePasswordForm = () => {
+  const navigate = useNavigate()
+  const [isLoading, setIsLoading] = useState(false)
+  const { openSnackbar } = useSnackbar()
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isValid },
+    watch,
+  } = useForm<ChangePasswordFormData>({
+    defaultValues: {
+      password: '',
+      confirmPassword: '',
+    },
+    mode: 'onChange',
+  })
+
+  const validationRules = ChangePasswordValidation(watch)
+
+  const onSubmit: SubmitHandler<ChangePasswordFormData> = async (data) => {
+    setIsLoading(true)
+
+    const requestData = {
+      user: {
+        current_password: data.currentPassword,
+        password: data.password,
+        password_confirmation: data.confirmPassword,
+      },
+    }
+
+    await axios({
+      method: 'PATCH',
+      url: API_ENDPOINTS.change_password,
+      data: requestData,
+      headers: getAuthHeaders(),
+    })
+      .then((res: AxiosResponse) => {
+        openSnackbar(res.data.message, 'success')
+        navigate('/drafts')
+      })
+      .catch((e: AxiosError<{ error: string | string[] }>) => {
+        console.log(e.message)
+        const errorMessage = e.response?.data?.error
+
+        if (typeof errorMessage === 'string') {
+          openSnackbar(errorMessage, 'error')
+        } else if (Array.isArray(errorMessage)) {
+          openSnackbar(errorMessage.join('、'), 'error')
+        } else {
+          openSnackbar('パスワードの変更に失敗しました', 'error')
+        }
+      })
+      .finally(() => {
+        setIsLoading(false)
+      })
+  }
+
+  return (
+    <Container maxWidth="sm">
+      <Box marginTop={6}>
+        <TextAlignContainer align="center">
+          <Typography variant="h4">パスワード変更</Typography>
+        </TextAlignContainer>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <Input
+            name="currentPassword"
+            label="現在のパスワード"
+            control={control}
+            type="password"
+            rules={validationRules.currentPassword}
+            error={!!errors.currentPassword}
+          />
+          {errors.currentPassword && (
+            <ErrorMessage error={errors.currentPassword?.message} />
+          )}
+          <Input
+            name="password"
+            label="新しいパスワード"
+            control={control}
+            type="password"
+            rules={validationRules.password}
+            error={!!errors.password}
+          />
+          {errors.password && <ErrorMessage error={errors.password?.message} />}
+          <Input
+            name="confirmPassword"
+            label="新しいパスワード確認"
+            control={control}
+            type="password"
+            rules={validationRules.confirmPassword}
+            error={!!errors.confirmPassword}
+          />
+          {errors.confirmPassword && (
+            <ErrorMessage error={errors.confirmPassword?.message} />
+          )}
+          <Box mt={3}>
+            <SubmitButton
+              text="保存"
+              isLoading={isLoading}
+              disabled={!isValid}
+            />
+          </Box>
+        </form>
+      </Box>
+    </Container>
+  )
+}
+export default ChangePasswordForm

--- a/frontend/src/routes/Router.tsx
+++ b/frontend/src/routes/Router.tsx
@@ -1,4 +1,5 @@
 import { Routes, Route } from 'react-router-dom'
+import ChangePasswordForm from '../pages/ChangePasswordForm'
 import DraftForm from '../pages/DraftForm'
 import DraftIndex from '../pages/DraftIndex'
 import Home from '../pages/Home'
@@ -15,6 +16,7 @@ const Router = () => {
       <Route path="/signup" element={<Signup />} />
       <Route path="/signin" element={<Signin />} />
       <Route path="/signout" element={<Signout />} />
+      <Route path="/password/edit" element={<ChangePasswordForm />} />
       <Route path="/drafts" element={<DraftIndex />} />
       <Route path="/drafts/new" element={<DraftForm />} />
       <Route path="/drafts/:id" element={<DraftForm />} />

--- a/frontend/src/validations/changePasswordValidation.ts
+++ b/frontend/src/validations/changePasswordValidation.ts
@@ -1,0 +1,40 @@
+import { UseFormWatch } from 'react-hook-form'
+
+type ChangePasswordFormData = {
+  currentPassword: string
+  password: string
+  confirmPassword: string
+}
+
+export const ChangePasswordValidation = (
+  watch: UseFormWatch<ChangePasswordFormData>,
+) => ({
+  currentPassword: {
+    required: '現在のパスワードは必須です',
+  },
+  password: {
+    required: '新しいパスワードは必須です',
+    minLength: {
+      value: 8,
+      message: '新しいパスワードは8文字以上で入力してください',
+    },
+    maxLength: {
+      value: 128,
+      message: '新しいパスワードは128文字以下で入力してください',
+    },
+    pattern: {
+      value: /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]*$/,
+      message:
+        'パスワードは半角英字と数字をそれぞれ1文字以上含む必要があります',
+    },
+  },
+  confirmPassword: {
+    required: 'パスワード確認は必須です',
+    validate: (value: string) => {
+      if (value !== watch('password')) {
+        return '新しいパスワードが一致しません'
+      }
+      return true
+    },
+  },
+})


### PR DESCRIPTION
## 概要

## 関連するissue番号

- #21 

## 行ったこと

- deviseのコントローラをカスタマイズしてPasswordsコントローラ作成
- パスワード変更機能作成
- パスワード変更ページコンポーネント作成
- パスワード変更リクエスト作成
- ヘッダーにパスワード変更のリンクを作成

## 動作確認

フロントエンド http://localhost:3001/password/edit
バックエンド http://localhost:3000

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a secure password update option for authenticated users with clear validation and error feedback.
	- Added a settings dropdown in the header (with mobile support) that includes a shortcut to the password change page.
	- Launched a dedicated password change form with real-time validations to ensure a smooth update experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->