### PR TITLE
アカウント削除機能実装

### DIFF
--- a/backend/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/backend/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,4 +1,17 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  include DeviseTokenAuth::Concerns::SetUserByToken
+
+  before_action :authenticate_api_v1_user!, only: [:destroy]
+
+  def destroy
+    if current_api_v1_user.valid_password?(params[:password])
+      current_api_v1_user.destroy!
+      render json: { message: "アカウントが削除されました" }, status: :ok
+    else
+      render json: { error: "パスワードが正しくありません" }, status: :unprocessable_entity
+    end
+  end
+
   private
 
     def sign_up_params

--- a/frontend/src/components/form/FormHeading.tsx
+++ b/frontend/src/components/form/FormHeading.tsx
@@ -1,0 +1,19 @@
+import { Box, Typography } from '@mui/material'
+
+type FormHeadingProps = {
+  title: string
+  description: string
+}
+
+export const FormHeading = ({ title, description }: FormHeadingProps) => {
+  return (
+    <Box>
+      <Typography variant="h4" textAlign="center">
+        {title}
+      </Typography>
+      <Typography variant="body1" mt={6}>
+        {description}
+      </Typography>
+    </Box>
+  )
+}

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -97,12 +97,11 @@ export const Header = () => {
                         cursor: 'pointer',
                         color: 'inherit',
                       }}
-                      onClick={handleSettingsClick} // 設定をクリックでドロップダウン
+                      onClick={handleSettingsClick}
                     >
                       設定
                     </Typography>
 
-                    {/* 設定のドロップダウンメニュー */}
                     <Menu
                       anchorEl={anchorEl}
                       open={Boolean(anchorEl)}
@@ -114,6 +113,9 @@ export const Header = () => {
                     >
                       <MenuItem component={Link} to="/password/edit">
                         パスワード変更
+                      </MenuItem>
+                      <MenuItem component={Link} to="/account/delete">
+                        アカウント削除
                       </MenuItem>
                     </Menu>
                   </>
@@ -139,6 +141,9 @@ export const Header = () => {
                     </ListItem>
                     <ListItem component={Link} to="/password/edit">
                       <ListItemText primary="パスワード変更" />
+                    </ListItem>
+                    <ListItem component={Link} to="/account/delete">
+                      <ListItemText primary="アカウント削除" />
                     </ListItem>
                   </>
                 ) : (

--- a/frontend/src/components/utilities/Loading.tsx
+++ b/frontend/src/components/utilities/Loading.tsx
@@ -1,12 +1,17 @@
 import { CircularProgress } from '@mui/material'
 import { FlexContainer } from './FlexContainer'
 
-export const Loading = () => (
+type LoadingProps = {
+  message?: string
+}
+
+export const Loading = ({ message }: LoadingProps) => (
   <FlexContainer
     alignItems="center"
     justifyContent="center"
     sx={{ height: '100vh' }}
   >
     <CircularProgress />
+    {message}
   </FlexContainer>
 )

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -4,6 +4,7 @@ export const API_ENDPOINTS = {
   signup: `${BASE_URL}/api/v1/auth`,
   signin: `${BASE_URL}/api/v1/auth/sign_in`,
   change_password: `${BASE_URL}/api/v1/auth/password`,
+  delete_account: `${BASE_URL}/api/v1/auth`,
   current_user: `${BASE_URL}/api/v1/current/user`,
   drafts: {
     index: (page?: string) => `${BASE_URL}/api/v1/drafts/?page=${page}`,

--- a/frontend/src/hooks/useCurrentUser.tsx
+++ b/frontend/src/hooks/useCurrentUser.tsx
@@ -6,6 +6,7 @@ export const useCurrentUserState = () => {
     email: string
     isSignedIn: boolean
     isFetched: boolean
+    isDeleted: boolean
   }
 
   const fallbackData: currentUserStateType = {
@@ -13,6 +14,7 @@ export const useCurrentUserState = () => {
     email: '',
     isSignedIn: false,
     isFetched: false,
+    isDeleted: false,
   }
 
   const { data: state, mutate: setState } = useSWR('user', null, {

--- a/frontend/src/hooks/useRequireSignedIn.tsx
+++ b/frontend/src/hooks/useRequireSignedIn.tsx
@@ -9,7 +9,11 @@ export const useRequireSignedIn = () => {
   const { openSnackbar } = useSnackbar()
 
   useEffect(() => {
-    if (currentUser.isFetched && !currentUser.isSignedIn) {
+    if (
+      currentUser.isFetched &&
+      !currentUser.isSignedIn &&
+      !currentUser.isDeleted
+    ) {
       openSnackbar('ログインが必要です', 'error')
       navigate('/signin')
     }

--- a/frontend/src/pages/ChangePasswordForm.tsx
+++ b/frontend/src/pages/ChangePasswordForm.tsx
@@ -9,6 +9,7 @@ import { SubmitButton } from '../components/form/SubmitButton'
 import { TextAlignContainer } from '../components/utilities/TextAlignContainer'
 import { API_ENDPOINTS } from '../config/api'
 import { useSnackbar } from '../context/SnackbarContext'
+import { useRequireSignedIn } from '../hooks/useRequireSignedIn'
 import { getAuthHeaders } from '../utils/getRequestHeaders'
 import { ChangePasswordValidation } from '../validations/changePasswordValidation'
 
@@ -19,6 +20,7 @@ type ChangePasswordFormData = {
 }
 
 const ChangePasswordForm = () => {
+  useRequireSignedIn()
   const navigate = useNavigate()
   const [isLoading, setIsLoading] = useState(false)
   const { openSnackbar } = useSnackbar()

--- a/frontend/src/pages/DeleteAccountForm.tsx
+++ b/frontend/src/pages/DeleteAccountForm.tsx
@@ -1,0 +1,184 @@
+import {
+  Box,
+  Button,
+  Container,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@mui/material'
+import axios, { AxiosError, AxiosResponse } from 'axios'
+import { useState } from 'react'
+import { useForm, SubmitHandler } from 'react-hook-form'
+import { useNavigate } from 'react-router'
+import { ErrorMessage } from '../components/form/ErrorMessage'
+import { FormHeading } from '../components/form/FormHeading'
+import { Input } from '../components/form/Input'
+import { SubmitButton } from '../components/form/SubmitButton'
+import { Loading } from '../components/utilities/Loading'
+import { API_ENDPOINTS } from '../config/api'
+import { useSnackbar } from '../context/SnackbarContext'
+import { useCurrentUserState } from '../hooks/useCurrentUser'
+import { useRequireSignedIn } from '../hooks/useRequireSignedIn'
+import { clearAuthStorage } from '../utils/authStorage'
+import { getAuthHeaders } from '../utils/getRequestHeaders'
+import { deleteAccountValidation } from '../validations/deleteAccountValidation'
+
+type DeleteAccountFormData = {
+  password: string
+}
+
+const DeleteAccountForm = () => {
+  useRequireSignedIn()
+  const navigate = useNavigate()
+  const { openSnackbar } = useSnackbar()
+  const [, setCurrentUser] = useCurrentUserState()
+  const [openModal, setOpenModal] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [formData, setFormData] = useState<DeleteAccountFormData | null>(null)
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<DeleteAccountFormData>({
+    defaultValues: { password: '' },
+    mode: 'onChange',
+  })
+
+  const handleDeleteConfirm = async () => {
+    if (!formData) return
+    setOpenModal(false)
+    setIsLoading(true)
+
+    axios({
+      method: 'DELETE',
+      url: API_ENDPOINTS.delete_account,
+      data: formData,
+      headers: getAuthHeaders(),
+    })
+      .then((res: AxiosResponse) => {
+        clearAuthStorage()
+        setCurrentUser({
+          id: 0,
+          email: '',
+          isSignedIn: false,
+          isFetched: true,
+          isDeleted: true,
+        })
+        openSnackbar(res.data.message, 'success')
+        navigate('/signin')
+      })
+      .catch((e: AxiosError<{ error: string }>) => {
+        const errorMessage =
+          e.response?.data?.error || 'アカウントの削除に失敗しました'
+        openSnackbar(errorMessage, 'error')
+      })
+      .finally(() => {
+        setIsLoading(false)
+        setOpenModal(false)
+      })
+  }
+
+  const handleDeleteCancel = () => {
+    setOpenModal(false)
+  }
+
+  const handleDeleteClick = (data: DeleteAccountFormData) => {
+    setFormData(data)
+    setOpenModal(true)
+  }
+
+  const onSubmit: SubmitHandler<DeleteAccountFormData> = (data) => {
+    handleDeleteClick(data)
+  }
+
+  return (
+    <>
+      {!isLoading ? (
+        <>
+          <Container maxWidth="sm">
+            <Box marginTop={6}>
+              <FormHeading
+                title="アカウント削除"
+                description="アカウント削除にはパスワードの再入力が必要です。"
+              />
+              <form onSubmit={handleSubmit(onSubmit)}>
+                <Input
+                  name="password"
+                  label="パスワード"
+                  control={control}
+                  type="password"
+                  rules={deleteAccountValidation.password}
+                  error={!!errors.password}
+                />
+                {errors.password && (
+                  <ErrorMessage error={errors.password?.message} />
+                )}
+                <Box mt={3}>
+                  <SubmitButton
+                    text="削除"
+                    isLoading={isLoading}
+                    disabled={!isValid}
+                  />
+                </Box>
+              </form>
+            </Box>
+          </Container>
+
+          <Dialog
+            open={openModal}
+            onClose={handleDeleteCancel}
+            maxWidth="sm"
+            fullWidth
+          >
+            <DialogTitle>アカウント削除確認</DialogTitle>
+            <DialogContent>
+              <Typography>本当にアカウントを削除しますか？</Typography>
+              <Typography
+                sx={{
+                  mt: 1,
+                  color: (theme) => theme.palette.error.dark, // エラーカラーパレットのダークカラーを使用
+                }}
+              >
+                ※アカウントを削除すると、すべてのデータが失われ、元に戻すことはできません。
+              </Typography>
+            </DialogContent>
+            <DialogActions>
+              <Button
+                onClick={handleDeleteCancel}
+                sx={{
+                  backgroundColor: '#F9F9F9',
+                  border: '1px solid #ccc',
+                  color: 'black',
+                  '&:hover': {
+                    backgroundColor: '#f0f0f0',
+                  },
+                }}
+              >
+                キャンセル
+              </Button>
+              <Button
+                onClick={handleDeleteConfirm}
+                sx={{
+                  backgroundColor: '#000',
+                  color: '#F9F9F9',
+                  '&:hover': {
+                    backgroundColor: '#333',
+                  },
+                }}
+              >
+                削除
+              </Button>
+            </DialogActions>
+          </Dialog>
+        </>
+      ) : (
+        <Loading message="アカウントを削除しています..." />
+      )}
+    </>
+  )
+}
+
+export default DeleteAccountForm

--- a/frontend/src/pages/Signout.tsx
+++ b/frontend/src/pages/Signout.tsx
@@ -13,6 +13,7 @@ const Signout = () => {
       email: '',
       isSignedIn: false,
       isFetched: true,
+      isDeleted: false,
     })
     navigate('/signin')
   }, [navigate, setCurrentUser])

--- a/frontend/src/routes/Router.tsx
+++ b/frontend/src/routes/Router.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route } from 'react-router-dom'
 import ChangePasswordForm from '../pages/ChangePasswordForm'
+import DeleteAccountForm from '../pages/DeleteAccountForm'
 import DraftForm from '../pages/DraftForm'
 import DraftIndex from '../pages/DraftIndex'
 import Home from '../pages/Home'
@@ -17,6 +18,7 @@ const Router = () => {
       <Route path="/signin" element={<Signin />} />
       <Route path="/signout" element={<Signout />} />
       <Route path="/password/edit" element={<ChangePasswordForm />} />
+      <Route path="/account/delete" element={<DeleteAccountForm />} />
       <Route path="/drafts" element={<DraftIndex />} />
       <Route path="/drafts/new" element={<DraftForm />} />
       <Route path="/drafts/:id" element={<DraftForm />} />

--- a/frontend/src/validations/deleteAccountValidation.ts
+++ b/frontend/src/validations/deleteAccountValidation.ts
@@ -1,0 +1,13 @@
+export const deleteAccountValidation = {
+  password: {
+    required: 'パスワードは必須です',
+    minLength: {
+      value: 8,
+      message: 'パスワードは8文字以上で入力してください',
+    },
+    maxLength: {
+      value: 128,
+      message: 'パスワードは128文字以下で入力してください',
+    },
+  },
+}


### PR DESCRIPTION
## 概要

アカウント削除機能実装

## 関連するissue番号

- #19 

## 行ったこと

- アカウント削除機能実装
- アカウント削除のリクエストスペック作成
- currentUserにisDeletedを追加
- アカウント削除ページコンポーネント作成

## 動作確認

フロントエンド http://localhost:3001/account/delete
バックエンド http://localhost:3000

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced secure account deletion functionality with password confirmation.
	- Added a dedicated account deletion page with confirmation dialogs and integrated navigation options.
	- Enhanced UI components (form headings and loading indicators) and updated API configurations and state management to support deletion.
	- Updated hooks to manage the user’s deletion status.
- **Tests**
	- Added comprehensive tests covering successful deletion, incorrect credentials, and unauthorized deletion attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->